### PR TITLE
Explain major version on Helm Chart version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade node version on Dockerfile
 - Upgrade outdated libs
 - Upgrade correction for vulnerability find on Veracode for Axios lib
+- Increase of the Chart version in the chart.yaml file to version: 3.0.3, version incremented from 1.1.0 to 3.0.3 due to the lack of updates that accompanied the subcharts updates.
+  Version released with compatibility and tracking of the referred subcharts.
 
 ## [1.2.0] - 2023-10-11
 


### PR DESCRIPTION
## Description

Increase of the Chart version in the chart.yaml file to version: 3.0.3, version incremented from 1.1.0 to 3.0.3 due to the lack of updates that accompanied the subcharts updates.
Version released with compatibility and tracking of the referred subcharts.

https://github.com/eclipse-tractusx/vas-country-risk/issues/54

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
