### PR TITLE
Remove unnecessarily overwriting default subchart values

### DIFF
--- a/.github/workflows/helm-chart-test.yaml
+++ b/.github/workflows/helm-chart-test.yaml
@@ -82,7 +82,7 @@ jobs:
           helm repo add pgadmin4 https://helm.runix.net
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install country-risk tractusx-dev/country-risk --version ${{ github.event.inputs.upgrade_from  }}
+          helm install country-risk tractusx-dev/country-risk --version ${{ github.event.inputs.upgrade_from || '1.1.0' }}
           helm dependency update charts/country-risk
           helm upgrade country-risk charts/country-risk
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 3.0.3
+version: 3.0.4
 appVersion: "1.2.1"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend

--- a/charts/country-risk/values.yaml
+++ b/charts/country-risk/values.yaml
@@ -22,14 +22,6 @@
 country-risk-frontend:
   replicaCount: 1
 
-  image:
-    registry: "tractusx"
-    # -- Name of the docker image
-    name: "vas-country-risk"
-    pullPolicy: Always
-    # -- Overrides the image tag whose default is the chart appVersion.
-    tag: ""
-
   certificate:
     # -- Hostname for the certificate
     host: "frontend.countryrisk.example.net"
@@ -154,13 +146,6 @@ country-risk-frontend:
 country-risk-backend:
 
   replicaCount: 1
-  image:
-    registry: "tractusx"
-    # -- Name of the docker image
-    name: "vas-country-risk-backend"
-    pullPolicy: Always
-    # -- Overrides the image tag whose default is the chart appVersion.
-    tag: ""
 
   certificate:
     # -- Hostname for the certificate


### PR DESCRIPTION
## Description

Image for both applications were removed and it used the default on subcharts
There will be only needed to override when there are specific versions/tags to use example https://github.com/catenax-ng/tx-vas-country-risk-frontend/blob/helm-env/charts/country-risk/values-dev.yaml


https://github.com/eclipse-tractusx/vas-country-risk/issues/55

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
