### PR TITLE
Upgrade charts to new version of applications

### DIFF
--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 3.0.4
+version: 3.0.5
 appVersion: "1.2.1"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend
@@ -38,6 +38,6 @@ dependencies:
   repository: https://helm.runix.net
   version: 1.x.x
 - name: country-risk-backend
-  version: 3.0.3
+  version: 3.0.4
 - name: country-risk-frontend
   version: 3.0.3

--- a/charts/country-risk/charts/country-risk-backend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-backend/Chart.yaml
@@ -36,13 +36,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.3
+version: 3.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.2.3"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Description
Backend version was upgraded and so for that charts increased on version.
Bumped charts version global release to 3.0.5 app version still on 1.2.1
Backend release to 3.0.4 appVersion new release to 1.2.3
Frontend still on 3.0.3 still on 1.2.1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
