### PR TITLE
fix(charts): Upgrade charts to new version of applications

### DIFF
--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 3.0.5
+version: 3.0.6
 appVersion: "1.2.1"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend
@@ -40,4 +40,4 @@ dependencies:
 - name: country-risk-backend
   version: 3.0.4
 - name: country-risk-frontend
-  version: 3.0.3
+  version: 3.0.4

--- a/charts/country-risk/charts/country-risk-frontend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/Chart.yaml
@@ -34,10 +34,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.3
+version: 3.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.3.0"


### PR DESCRIPTION
## Description
Upgrade charts and new charts version for frontend component
Use frontend release v1.3.0 application version

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
