### PR TITLE
Update dependency on vulnerability for @adobe/css-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - [unreleased]
 
 ### Fix
+- Update dependency on vulnerability for @adobe/css-tools
 - Fix styles on Save Reports and Upload Ratings
 
 ## [1.3.0] - 2023-12-06

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -181,7 +181,7 @@ npm/npmjs/-/cssom/0.3.8, MIT, approved, clearlydefined
 npm/npmjs/-/cssom/0.4.4, MIT, approved, clearlydefined
 npm/npmjs/-/cssstyle/2.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/cssstyle/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/csstype/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/csstype/3.1.2, MIT, approved, #11847
 npm/npmjs/-/cx-portal-shared-components/0.4.5, Apache-2.0 AND MIT AND OFL-1.1, approved, #3009
 npm/npmjs/-/d3-array/2.12.1, BSD-3-Clause AND ISC, approved, #3486
 npm/npmjs/-/d3-color/3.1.0, ISC, approved, clearlydefined
@@ -1108,7 +1108,7 @@ npm/npmjs/-/yargs/16.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/yargs/17.7.2, MIT, approved, #8222
 npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
 npm/npmjs/@aashutoshrathi/word-wrap/1.2.6, MIT, approved, #9212
-npm/npmjs/@adobe/css-tools/4.3.1, MIT, approved, #9985
+npm/npmjs/@adobe/css-tools/4.3.2, MIT, approved, #9985
 npm/npmjs/@alloc/quick-lru/5.2.0, MIT, approved, clearlydefined
 npm/npmjs/@ampproject/remapping/2.2.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/@apideck/better-ajv-errors/0.3.6, MIT, approved, clearlydefined
@@ -1328,6 +1328,7 @@ npm/npmjs/@mui/material/5.10.7, MIT, approved, #3244
 npm/npmjs/@mui/private-theming/5.14.20, MIT, approved, #10973
 npm/npmjs/@mui/styled-engine/5.14.20, MIT, approved, #10971
 npm/npmjs/@mui/system/5.14.20, MIT AND CC-BY-3.0, approved, #9905
+npm/npmjs/@mui/types/7.2.12, , restricted, clearlydefined
 npm/npmjs/@mui/types/7.2.5, MIT, approved, clearlydefined
 npm/npmjs/@mui/utils/5.14.20, MIT AND CC-BY-3.0, approved, #9891
 npm/npmjs/@mui/x-data-grid/5.17.26, MIT, approved, #3248

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -895,7 +895,7 @@ npm/npmjs/-/semver/6.3.1, ISC, approved, clearlydefined
 npm/npmjs/-/semver/7.5.4, ISC, approved, clearlydefined
 npm/npmjs/-/send/0.18.0, MIT, approved, clearlydefined
 npm/npmjs/-/serialize-javascript/4.0.0, BSD-3-Clause, approved, clearlydefined
-npm/npmjs/-/serialize-javascript/6.0.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/serialize-javascript/6.0.1, BSD-3-Clause, approved, #12680
 npm/npmjs/-/serve-index/1.9.1, MIT, approved, clearlydefined
 npm/npmjs/-/serve-static/1.15.0, MIT, approved, clearlydefined
 npm/npmjs/-/set-function-length/1.1.1, MIT, approved, #11090
@@ -953,7 +953,7 @@ npm/npmjs/-/strip-comments/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/strip-final-newline/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-indent/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-json-comments/3.1.1, MIT, approved, clearlydefined
-npm/npmjs/-/style-loader/3.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/style-loader/3.3.3, MIT, approved, #12669
 npm/npmjs/-/stylehacks/5.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/stylis/4.2.0, MIT, approved, #8409
 npm/npmjs/-/sucrase/3.34.0, MIT, approved, clearlydefined
@@ -1328,7 +1328,7 @@ npm/npmjs/@mui/material/5.10.7, MIT, approved, #3244
 npm/npmjs/@mui/private-theming/5.14.20, MIT, approved, #10973
 npm/npmjs/@mui/styled-engine/5.14.20, MIT, approved, #10971
 npm/npmjs/@mui/system/5.14.20, MIT AND CC-BY-3.0, approved, #9905
-npm/npmjs/@mui/types/7.2.12, , restricted, clearlydefined
+npm/npmjs/@mui/types/7.2.12, MIT, approved, clearlydefined
 npm/npmjs/@mui/types/7.2.5, MIT, approved, clearlydefined
 npm/npmjs/@mui/utils/5.14.20, MIT AND CC-BY-3.0, approved, #9891
 npm/npmjs/@mui/x-data-grid/5.17.26, MIT, approved, #3248

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "webpack": "5.89.0"
       },
       "devDependencies": {
+        "@adobe/css-tools": ">=4.3.2",
         "@babel/core": "^7.23.3",
         "@babel/preset-env": "^7.23.3",
         "@babel/preset-react": "^7.23.3",
@@ -57,8 +58,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "license": "MIT"
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3241,6 +3243,19 @@
         "@emotion/styled": {
           "optional": true
         },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system/node_modules/@mui/types": {
+      "version": "7.2.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.12.tgz",
+      "integrity": "sha512-3kaHiNm9khCAo0pVe0RenketDSFoZGAlVZ4zDjB/QNZV0XiCj+sh1zkX0VVhQPgYJDlBEzAag+MHJ1tU3vf0Zw==",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "@babel/preset-react": "^7.23.3",
     "babel-jest": "^29.7.0",
     "jsdom": "22.0.0",
-    "sass": "^1.69.5"
+    "sass": "^1.69.5",
+    "@adobe/css-tools": ">=4.3.2"
   },
   "overrides": {
     "react-simple-maps": {


### PR DESCRIPTION
## Description
Fix Vulnerability for Veracode scan 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
