### PR TITLE
Update header for TRG 7.0.2

### DIFF
--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -1,6 +1,6 @@
 ################################################################################
- # Copyright (c) 2022,2023 BMW Group AG
- # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ # Copyright (c) 2022,2024 BMW Group AG
+ # Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  #
  # See the NOTICE file(s) distributed with this work for additional
  # information regarding copyright ownership.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #********************************************************************************
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/chart-testing-config.yaml
+++ b/charts/chart-testing-config.yaml
@@ -1,6 +1,6 @@
 #********************************************************************************
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 3.0.10
+version: 3.0.9
 appVersion: "1.3.0"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend
@@ -38,6 +38,6 @@ dependencies:
   repository: https://helm.runix.net
   version: 1.x.x
 - name: country-risk-backend
-  version: 3.0.7
+  version: 3.0.6
 - name: country-risk-frontend
-  version: 3.0.5
+  version: 3.0.4

--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -1,6 +1,6 @@
 ###############################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 3.0.9
+version: 3.0.10
 appVersion: "1.3.0"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend
@@ -38,6 +38,6 @@ dependencies:
   repository: https://helm.runix.net
   version: 1.x.x
 - name: country-risk-backend
-  version: 3.0.6
+  version: 3.0.7
 - name: country-risk-frontend
-  version: 3.0.4
+  version: 3.0.5

--- a/charts/country-risk/charts/country-risk-backend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-backend/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.7
+version: 3.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/country-risk/charts/country-risk-backend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-backend/Chart.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.6
+version: 3.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/country-risk/charts/country-risk-backend/templates/_helpers.tpl
+++ b/charts/country-risk/charts/country-risk-backend/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 ********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/application-secret.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/application-secret.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG 
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/configmap.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/configmap.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/deployment.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/deployment.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/ingress.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/ingress.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/secret-pgadmin4.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/secret-pgadmin4.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/templates/service.yaml
+++ b/charts/country-risk/charts/country-risk-backend/templates/service.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-backend/values.yaml
+++ b/charts/country-risk/charts/country-risk-backend/values.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -34,7 +34,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.4
+version: 3.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/country-risk/charts/country-risk-frontend/Chart.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/Chart.yaml
@@ -34,7 +34,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.5
+version: 3.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/country-risk/charts/country-risk-frontend/templates/_helpers.tpl
+++ b/charts/country-risk/charts/country-risk-frontend/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 ********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/templates/configmap.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/templates/configmap.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/templates/deployment.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/templates/ingress.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/templates/service.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/templates/service.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/charts/country-risk-frontend/values.yaml
+++ b/charts/country-risk/charts/country-risk-frontend/values.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/country-risk/values.yaml
+++ b/charts/country-risk/values.yaml
@@ -1,6 +1,6 @@
 ###############################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/helper/backend/_helpers.tpl
+++ b/charts/helper/backend/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 ********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/helper/frontend/_helpers.tpl
+++ b/charts/helper/frontend/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 ********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/scripts/inject-dynamic-env.sh
+++ b/scripts/inject-dynamic-env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/scripts/legal-notice.sh
+++ b/scripts/legal-notice.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ################################################################################
-# Copyright (c) 2022,2023 BMW Group AG
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 BMW Group AG
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/AboutCard/AboutPage.js
+++ b/src/components/dashboard/AboutCard/AboutPage.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/AboutCard/about.scss
+++ b/src/components/dashboard/AboutCard/about.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/CountryPicker/CountryPicker.js
+++ b/src/components/dashboard/CountryPicker/CountryPicker.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/CountryPicker/styles.scss
+++ b/src/components/dashboard/CountryPicker/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/CustomCompanyMap/CustomCompanyMap.js
+++ b/src/components/dashboard/CustomCompanyMap/CustomCompanyMap.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/CustomCompanyMap/styles.scss
+++ b/src/components/dashboard/CustomCompanyMap/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/CustomWorld/CustomWorldMap.js
+++ b/src/components/dashboard/CustomWorld/CustomWorldMap.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/CustomWorld/styles.scss
+++ b/src/components/dashboard/CustomWorld/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DashBoardTable/DashboardTable.js
+++ b/src/components/dashboard/DashBoardTable/DashboardTable.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/DashBoardTable/styles.scss
+++ b/src/components/dashboard/DashBoardTable/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DashBoardTable/tableColumns.js
+++ b/src/components/dashboard/DashBoardTable/tableColumns.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/DatePicker/DatePicker.js
+++ b/src/components/dashboard/DatePicker/DatePicker.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DatePicker/styles.scss
+++ b/src/components/dashboard/DatePicker/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DeleteUpdateComponent/DeleteUpdateComponent.js
+++ b/src/components/dashboard/DeleteUpdateComponent/DeleteUpdateComponent.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/DeleteUpdateComponent/styles.scss
+++ b/src/components/dashboard/DeleteUpdateComponent/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DetailDialog/DetailDialog.js
+++ b/src/components/dashboard/DetailDialog/DetailDialog.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/DetailDialog/styles.scss
+++ b/src/components/dashboard/DetailDialog/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/DetailGrid/DetailGrid.js
+++ b/src/components/dashboard/DetailGrid/DetailGrid.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/Footer/Constants.js
+++ b/src/components/dashboard/Footer/Constants.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/Footer/Footer.scss
+++ b/src/components/dashboard/Footer/Footer.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/Footer/FooterPortal.js
+++ b/src/components/dashboard/Footer/FooterPortal.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/GatePicker/GatePicker.js
+++ b/src/components/dashboard/GatePicker/GatePicker.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/GatePicker/styles.scss
+++ b/src/components/dashboard/GatePicker/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/LeftMap/LeftMap.js
+++ b/src/components/dashboard/LeftMap/LeftMap.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/LeftMap/styles.scss
+++ b/src/components/dashboard/LeftMap/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/NavigationBar/DialogContent/DialogHelpContent.js
+++ b/src/components/dashboard/NavigationBar/DialogContent/DialogHelpContent.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/NavigationBar/NavigationBar.js
+++ b/src/components/dashboard/NavigationBar/NavigationBar.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/NavigationBar/UserInformation/UserInfo.js
+++ b/src/components/dashboard/NavigationBar/UserInformation/UserInfo.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/NavigationBar/styles.scss
+++ b/src/components/dashboard/NavigationBar/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/PageBreadCrumb/PageBreadcrumb.js
+++ b/src/components/dashboard/PageBreadCrumb/PageBreadcrumb.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/PrintMap/PrintMap.js
+++ b/src/components/dashboard/PrintMap/PrintMap.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/PrintMap/styles.scss
+++ b/src/components/dashboard/PrintMap/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/ProgressBar/ProgressBar.js
+++ b/src/components/dashboard/ProgressBar/ProgressBar.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/ProgressBar/styles.scss
+++ b/src/components/dashboard/ProgressBar/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/RangeSlider/RangeSlider.js
+++ b/src/components/dashboard/RangeSlider/RangeSlider.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/RangeSlider/styles.scss
+++ b/src/components/dashboard/RangeSlider/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/Ratings/Ratings.js
+++ b/src/components/dashboard/Ratings/Ratings.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/Ratings/ratingUserColumns.js
+++ b/src/components/dashboard/Ratings/ratingUserColumns.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/Ratings/styles.scss
+++ b/src/components/dashboard/Ratings/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/Reports/Reports.js
+++ b/src/components/dashboard/Reports/Reports.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/Reports/styles.scss
+++ b/src/components/dashboard/Reports/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/RightMap/RightMap.js
+++ b/src/components/dashboard/RightMap/RightMap.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/RightMap/styles.scss
+++ b/src/components/dashboard/RightMap/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/ShareReport/ShareReport.js
+++ b/src/components/dashboard/ShareReport/ShareReport.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/ShareReport/styles.scss
+++ b/src/components/dashboard/ShareReport/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/UploadDownloadZone/UploadDownloadZone.js
+++ b/src/components/dashboard/UploadDownloadZone/UploadDownloadZone.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/dashboard/UploadDownloadZone/dialog-upload.scss
+++ b/src/components/dashboard/UploadDownloadZone/dialog-upload.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/all.scss
+++ b/src/components/dashboard/all.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/dashboard.js
+++ b/src/components/dashboard/dashboard.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/dashboard/styles.scss
+++ b/src/components/dashboard/styles.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/model/CompanyUser.js
+++ b/src/components/model/CompanyUser.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/model/DeleteOrUpdate.js
+++ b/src/components/model/DeleteOrUpdate.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/model/Range.js
+++ b/src/components/model/Range.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/model/Report.js
+++ b/src/components/model/Report.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/EnvironmentService.js
+++ b/src/components/services/EnvironmentService.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/services/LogService.js
+++ b/src/components/services/LogService.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/UserService.js
+++ b/src/components/services/UserService.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/services/bpns-api.js
+++ b/src/components/services/bpns-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/services/company-api.js
+++ b/src/components/services/company-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/country-api.js
+++ b/src/components/services/country-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/dashboard-api.js
+++ b/src/components/services/dashboard-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/dateform-api.js
+++ b/src/components/services/dateform-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/files-api.js
+++ b/src/components/services/files-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/gate-api.js
+++ b/src/components/services/gate-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/ranges-api.js
+++ b/src/components/services/ranges-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/ratingstable-api.js
+++ b/src/components/services/ratingstable-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/components/services/reports-api.js
+++ b/src/components/services/reports-api.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/companyuser/index.js
+++ b/src/contexts/companyuser/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/country/index.js
+++ b/src/contexts/country/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/gates/index.js
+++ b/src/contexts/gates/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/ranges/index.js
+++ b/src/contexts/ranges/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/rates/index.js
+++ b/src/contexts/rates/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/refresh/index.js
+++ b/src/contexts/refresh/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/contexts/reports/index.js
+++ b/src/contexts/reports/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/index-dev.scss
+++ b/src/index-dev.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/index-int.scss
+++ b/src/index-int.scss
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/CountryPicker/CountryPicker.test.js
+++ b/src/tests/dashboard/CountryPicker/CountryPicker.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/CustomCompanyMap/CustomCompanyMap.test.js
+++ b/src/tests/dashboard/CustomCompanyMap/CustomCompanyMap.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/CustomWorldMap/CustomWorldMap.test.js
+++ b/src/tests/dashboard/CustomWorldMap/CustomWorldMap.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/GatePicker/GatePicker.test.js
+++ b/src/tests/dashboard/GatePicker/GatePicker.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/ShareReports/ShareReport.test.js
+++ b/src/tests/dashboard/ShareReports/ShareReport.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/UploadDownload/UploadDownload.test.js
+++ b/src/tests/dashboard/UploadDownload/UploadDownload.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/tests/dashboard/app/app.test.js
+++ b/src/tests/dashboard/app/app.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/tests/dashboard/dashboard/DashboardTable.test.js
+++ b/src/tests/dashboard/dashboard/DashboardTable.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/datepicker/DatePicker.test.js
+++ b/src/tests/dashboard/datepicker/DatePicker.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/tests/dashboard/deleteUpdate/DeleteUpdate.test.js
+++ b/src/tests/dashboard/deleteUpdate/DeleteUpdate.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/detaildialog/DetailDialog.test.js
+++ b/src/tests/dashboard/detaildialog/DetailDialog.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/index/index.test.js
+++ b/src/tests/dashboard/index/index.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/tests/dashboard/leftmap/LeftMap.test.js
+++ b/src/tests/dashboard/leftmap/LeftMap.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/ranges/Ranges.test.js
+++ b/src/tests/dashboard/ranges/Ranges.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/ratings/Ratings.test.js
+++ b/src/tests/dashboard/ratings/Ratings.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/report/Reports.test.js
+++ b/src/tests/dashboard/report/Reports.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/dashboard/rightmap/RightMap.test.js
+++ b/src/tests/dashboard/rightmap/RightMap.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/bpns-api.test.js
+++ b/src/tests/services/bpns-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/company-api.test.js
+++ b/src/tests/services/company-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/country-api.test.js
+++ b/src/tests/services/country-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/dashboard-api.test.js
+++ b/src/tests/services/dashboard-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/tests/services/dateform-api.test.js
+++ b/src/tests/services/dateform-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/files-api.test.js
+++ b/src/tests/services/files-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/gate-api.test.js
+++ b/src/tests/services/gate-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/ranges-api.test.js
+++ b/src/tests/services/ranges-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/ratingstable-api.test.js
+++ b/src/tests/services/ratingstable-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/src/tests/services/report-api.test.js
+++ b/src/tests/services/report-api.test.js
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022,2023 BMW Group AG
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 BMW Group AG
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/types/Constants.js
+++ b/src/types/Constants.js
@@ -1,6 +1,6 @@
 /********************************************************************************
-* Copyright (c) 2022,2023 BMW Group AG 
-* Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2022,2024 BMW Group AG
+* Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.


### PR DESCRIPTION
## Description
All files must have the header updated from 2023 to 2024



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
