### PR TITLE
docs(frontend): Update repo correct links and dependency file

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,7 +28,8 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-tractusx/vas-country-risk-frontend
+* https://github.com/eclipse-tractusx/vas-country-risk
+* https://github.com/eclipse-tractusx/vas-country-risk-backend
 
 
 ## Third-party Content
@@ -36,6 +37,8 @@ The project maintains the following source code repositories:
 This project leverages the following third party content.
 
 See DEPENDENCIES file.
+
+* [Dependency File](./DEPENDENCIES)
 
 ## Cryptography
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -36,10 +36,7 @@ The project maintains the following source code repositories:
 
 This project leverages the following third party content.
 
-See DEPENDENCIES file.
-
-* [Dependency File](./DEPENDENCIES)
-
+See [DEPENDENCIES](https://github.com/eclipse-tractusx/vas-country-risk/blob/main/DEPENDENCIES) file.
 ## Cryptography
 
 Content may contain encryption software. The country in which you are currently


### PR DESCRIPTION

## Description
Update repo correct links and dependency file
Added backend repo 

Fixes: https://github.com/eclipse-tractusx/vas-country-risk/issues/97 https://github.com/eclipse-tractusx/vas-country-risk/issues/100

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
