### PR TITLE
Release new version for frontend application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.1] - [unreleased]
+## [1.3.1] - [2024-02-29]
 
 ### Fix
 - Update dependency on vulnerability for @adobe/css-tools and axios


### PR DESCRIPTION
## Description
Release version for country risk front end 1.3.1

On going: https://github.com/eclipse-tractusx/vas-country-risk/issues/67

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
