### PR TITLE
fix(Frontend): Fix vulnerabilities and merge dependabot versions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
-  </component>
-  <component name="ProjectType">
-    <option name="id" value="jpab" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/product-vas-country-risk-frontend.iml" filepath="$PROJECT_DIR$/.idea/product-vas-country-risk-frontend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/vas-country-risk.iml" filepath="$PROJECT_DIR$/.idea/vas-country-risk.iml" />
     </modules>
   </component>
 </project>

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,30 +1,71 @@
-npm/npmjs/-/axios/1.6.4, MIT, approved, #11338
-npm/npmjs/-/clsx/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/body-parser/1.20.2, MIT, approved, clearlydefined
+npm/npmjs/-/browserslist/4.23.0, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/caniuse-lite/1.0.30001607, CC-BY-4.0, approved, #1196
+npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/clsx/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/1.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/content-type/1.0.5, MIT, approved, #6950
+npm/npmjs/-/cookie/0.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/cssstyle/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/csstype/3.1.3, MIT, approved, #11847
 npm/npmjs/-/data-urls/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/debug/2.6.9, MIT, approved, clearlydefined
 npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/follow-redirects/1.15.5, MIT, approved, #10782
+npm/npmjs/-/electron-to-chromium/1.4.729, ISC, approved, #1950
+npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/express/4.19.2, MIT, approved, clearlydefined
+npm/npmjs/-/follow-redirects/1.15.6, MIT, approved, #10782
+npm/npmjs/-/has-flag/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/html-parse-stringify/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/http-proxy-agent/5.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/i18next/22.5.1, MIT, approved, #9143
+npm/npmjs/-/iconv-lite/0.4.24, MIT, approved, clearlydefined
 npm/npmjs/-/jsdom/22.0.0, MIT AND LGPL-2.0-or-later, approved, #8188
-npm/npmjs/-/react-i18next/13.5.0, MIT AND Apache-2.0, approved, #11697
+npm/npmjs/-/media-typer/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/node-releases/2.0.14, MIT, approved, #1954
+npm/npmjs/-/postcss/8.4.38, MIT, approved, #3545
+npm/npmjs/-/qs/6.11.0, BSD-3-Clause, approved, #7556
+npm/npmjs/-/raw-body/2.5.2, MIT, approved, clearlydefined
 npm/npmjs/-/rrweb-cssom/0.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/saxes/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/source-map-js/1.2.0, BSD-3-Clause, approved, #13911
+npm/npmjs/-/supports-color/5.5.0, MIT, approved, clearlydefined
 npm/npmjs/-/tr46/4.1.1, MIT, approved, clearlydefined
-npm/npmjs/-/void-elements/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
 npm/npmjs/-/w3c-xmlserializer/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/web-vitals/3.5.2, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/webidl-conversions/7.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webpack-dev-middleware/5.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/whatwg-encoding/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/whatwg-mimetype/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/whatwg-url/12.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/xml-name-validator/4.0.0, Apache-2.0, approved, clearlydefined
-npm/npmjs/@adobe/css-tools/4.3.2, MIT, approved, #9985
+npm/npmjs/@babel/code-frame/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
+npm/npmjs/@babel/compat-data/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13915
+npm/npmjs/@babel/core/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13942
+npm/npmjs/@babel/generator/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13919
+npm/npmjs/@babel/helper-compilation-targets/7.23.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-validator-option/7.23.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/helpers/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13922
+npm/npmjs/@babel/highlight/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
+npm/npmjs/@babel/parser/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
+npm/npmjs/@babel/runtime/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
+npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
+npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@catena-x/portal-shared-components/2.1.30, Apache-2.0 AND CC-BY-4.0, approved, #10502
-npm/npmjs/@mui/private-theming/5.14.20, MIT, approved, #10973
-npm/npmjs/@mui/styled-engine/5.14.20, MIT, approved, #10971
-npm/npmjs/@mui/system/5.14.20, MIT AND CC-BY-3.0, approved, #9905
-npm/npmjs/@mui/types/7.2.12, MIT, approved, clearlydefined
-npm/npmjs/@mui/x-data-grid/6.18.4, MIT AND ISC, approved, #11696
+npm/npmjs/@jridgewell/gen-mapping/0.3.5, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/set-array/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/trace-mapping/0.3.25, MIT, approved, #9904
+npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
+npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
+npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
+npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
+npm/npmjs/@mui/types/7.2.5, MIT, approved, clearlydefined
+npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
+npm/npmjs/@mui/x-data-grid/5.17.26, MIT, approved, #3248
+npm/npmjs/@mui/x-data-grid/7.1.1, , restricted, clearlydefined
 npm/npmjs/@tootallnate/once/2.0.0, MIT, approved, clearlydefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "5.10.6",
-        "@mui/types": "7.2.5",
-        "@mui/x-data-grid": "5.17.26",
+        "@mui/types": "^7.2.14",
+        "@mui/x-data-grid": "^7.1.1",
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "14.1.0",
         "@testing-library/user-event": "^14.5.1",
@@ -46,10 +46,12 @@
         "@babel/preset-env": "^7.23.3",
         "@babel/preset-react": "^7.23.3",
         "babel-jest": "^29.7.0",
-        "follow-redirects": ">=1.15.4",
+        "express": "^4.19.2",
+        "follow-redirects": ">=1.15.6",
         "jsdom": "22.0.0",
         "postcss": "^8.4.38",
-        "sass": "^1.69.5"
+        "sass": "^1.69.5",
+        "webpack-dev-middleware": "^5.3.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -61,8 +63,7 @@
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
-      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1809,8 +1810,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.4",
-      "license": "MIT",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1923,10 +1925,22 @@
         }
       }
     },
+    "node_modules/@catena-x/portal-shared-components/node_modules/@mui/types": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.5.tgz",
+      "integrity": "sha512-S2BwfNczr7VwS6ki8GoAXJyARoeSJDLuxOEPs3vEMyTALlf9PrdHv+sluX7kk3iKrCg/ML2mIWwapZvWbkMCQA==",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@catena-x/portal-shared-components/node_modules/@mui/x-data-grid": {
       "version": "6.18.4",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.18.4.tgz",
-      "integrity": "sha512-uiinfqioCRoesUlJF3gvh67Ja3TrJJvPRTu4Gkf/RQBjr0BDNQ8BJrnuffqD8D/0SVUiqRZvcrjtgG1BIyjKRw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@mui/utils": "^5.14.16",
@@ -3119,6 +3133,20 @@
         }
       }
     },
+    "node_modules/@mui/base/node_modules/@mui/types": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.5.tgz",
+      "integrity": "sha512-S2BwfNczr7VwS6ki8GoAXJyARoeSJDLuxOEPs3vEMyTALlf9PrdHv+sluX7kk3iKrCg/ML2mIWwapZvWbkMCQA==",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.14.18",
       "license": "MIT",
@@ -3197,12 +3225,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.20.tgz",
-      "integrity": "sha512-WV560e1vhs2IHCh0pgUaWHznrcrVoW9+cDCahU1VTkuwPokWVvb71ccWQ1f8Y3tRBPPcNkU2dChkkRJChLmQlQ==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
+      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@mui/utils": "^5.14.20",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.14",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3223,13 +3251,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.20.tgz",
-      "integrity": "sha512-Vs4nGptd9wRslo9zeRkuWcZeIEp+oYbODy+fiZKqqr4CH1Gfi9fdP0Q1tGYk8OiJ2EPB/tZSAyOy62Hyp/iP7g==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3254,17 +3282,17 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.20.tgz",
-      "integrity": "sha512-jKOGtK4VfYZG5kdaryUHss4X6hzcfh0AihT8gmnkfqRtWP7xjY+vPaUhhuSeibE5sqA5wCtdY75z6ep9pxFnIg==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
+      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@mui/private-theming": "^5.14.20",
-        "@mui/styled-engine": "^5.14.19",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.20",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.14",
+        "@mui/styled-engine": "^5.15.14",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3292,30 +3320,18 @@
         }
       }
     },
-    "node_modules/@mui/system/node_modules/@mui/types": {
-      "version": "7.2.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.12.tgz",
-      "integrity": "sha512-3kaHiNm9khCAo0pVe0RenketDSFoZGAlVZ4zDjB/QNZV0XiCj+sh1zkX0VVhQPgYJDlBEzAag+MHJ1tU3vf0Zw==",
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/system/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.5",
-      "license": "MIT",
+      "version": "7.2.14",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
+      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -3326,10 +3342,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.20",
-      "license": "MIT",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
+      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
+        "@babel/runtime": "^7.23.9",
         "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
@@ -3352,27 +3369,36 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "5.17.26",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.1.1.tgz",
+      "integrity": "sha512-hNvz927lkAznFdy45QPE7mIZVyQhlqveHmTK9+SD0N1us4sSTij90uUJ/roTNDod0VA9f5GqWmNz+5h8ihpz6Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@mui/utils": "^5.10.3",
-        "clsx": "^1.2.1",
+        "@babel/runtime": "^7.24.0",
+        "@mui/system": "^5.15.14",
+        "@mui/utils": "^5.15.14",
+        "clsx": "^2.1.0",
         "prop-types": "^15.8.1",
-        "reselect": "^4.1.6"
+        "reselect": "^4.1.8"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^5.4.1",
-        "@mui/system": "^5.4.1",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "@mui/material": "^5.15.14",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@mui/x-date-pickers": {
@@ -3462,6 +3488,19 @@
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/types": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.5.tgz",
+      "integrity": "sha512-S2BwfNczr7VwS6ki8GoAXJyARoeSJDLuxOEPs3vEMyTALlf9PrdHv+sluX7kk3iKrCg/ML2mIWwapZvWbkMCQA==",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4505,7 +4544,7 @@
       }
     },
     "node_modules/@types/react-redux": {
-      "version": "7.1.30",
+      "version": "7.1.33",
       "license": "MIT",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
@@ -4515,7 +4554,7 @@
       }
     },
     "node_modules/@types/react-slick": {
-      "version": "0.23.12",
+      "version": "0.23.13",
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -5472,8 +5511,7 @@
     },
     "node_modules/axios": {
       "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
-      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -5818,11 +5856,12 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "license": "MIT",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -5830,7 +5869,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -5841,21 +5880,24 @@
     },
     "node_modules/body-parser/node_modules/bytes": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/body-parser/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -5865,7 +5907,8 @@
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
@@ -6046,9 +6089,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001605",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
-      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
+      "version": "1.0.30001607",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
       "funding": [
         {
           "type": "opencollective",
@@ -6392,7 +6435,8 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6402,8 +6446,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "license": "MIT",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6966,8 +7011,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cx-portal-shared-components": {
       "version": "0.4.5",
@@ -6990,6 +7036,31 @@
         "@mui/material": "^5.4.4",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"
+      }
+    },
+    "node_modules/cx-portal-shared-components/node_modules/@mui/x-data-grid": {
+      "version": "5.17.26",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.17.26.tgz",
+      "integrity": "sha512-eGJq9J0g9cDGLFfMmugOadZx0mJeOd/yQpHwEa5gUXyONS6qF0OhXSWyDOhDdA3l2TOoQzotMN5dY/T4Wl1KYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "@mui/utils": "^5.10.3",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/cx-portal-shared-components/node_modules/react-slick": {
@@ -7537,9 +7608,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.725",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.725.tgz",
-      "integrity": "sha512-OGkMXLY7XH6ykHE5ZOVVIMHaGAvvxqw98cswTKB683dntBJre7ufm9wouJ0ExDm0VXhHenU8mREvxIbV5nNoVQ=="
+      "version": "1.4.729",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+      "integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8640,15 +8711,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "license": "MIT",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8914,9 +8986,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -9612,8 +9684,7 @@
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
       }
@@ -9762,8 +9833,6 @@
     },
     "node_modules/i18next": {
       "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.5.1.tgz",
-      "integrity": "sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==",
       "funding": [
         {
           "type": "individual",
@@ -9778,6 +9847,7 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.6"
       }
@@ -13493,7 +13563,8 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -15622,7 +15693,8 @@
     },
     "node_modules/qs": {
       "version": "6.11.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -15692,8 +15764,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "license": "MIT",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -15706,14 +15779,16 @@
     },
     "node_modules/raw-body/node_modules/bytes": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/raw-body/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -15909,8 +15984,7 @@
     },
     "node_modules/react-i18next": {
       "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
-      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "html-parse-stringify": "^3.0.1"
@@ -19217,7 +19291,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -19481,8 +19556,7 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19532,8 +19606,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.0",
-      "license": "Apache-2.0"
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -19590,8 +19665,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "license": "MIT",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "5.10.6",
-    "@mui/x-data-grid": "5.17.26",
-    "@mui/types": "7.2.5",
+    "@mui/x-data-grid": "^7.1.1",
+    "@mui/types": "^7.2.14",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "14.1.0",
     "@testing-library/user-event": "^14.5.1",
@@ -74,8 +74,10 @@
     "jsdom": "22.0.0",
     "sass": "^1.69.5",
     "@adobe/css-tools": ">=4.3.2",
-    "follow-redirects": ">=1.15.4",
-    "postcss": "^8.4.38"
+    "follow-redirects": ">=1.15.6",
+    "postcss": "^8.4.38",
+    "express": "^4.19.2",
+    "webpack-dev-middleware": "^5.3.4"
   },
   "overrides": {
     "react-simple-maps": {
@@ -86,7 +88,7 @@
       "@svgr/webpack": "7.0.0"
     },
     "resolve-url-loader": {
-      "postcss": "^8.4.31"
+      "postcss": "^8.4.38"
     },
     "eslint": "8.32.0",
     "react-router-dom": "6.14.1",


### PR DESCRIPTION
## Description
Fix to update outdated libs 
Correct dependencies from dependabot
Correct High findings on security


Fixes: https://github.com/eclipse-tractusx/vas-country-risk/issues/106 https://github.com/eclipse-tractusx/vas-country-risk/pull/140 https://github.com/eclipse-tractusx/vas-country-risk/pull/126


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
