### PR TITLE
Release version of 2.0.0 for country risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project (both backend and frontend) will be document
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - [unreleased]
+## [2.0.0] - [21-05-2024]
 
 ### Frontend
 

--- a/charts/country-risk/Chart.yaml
+++ b/charts/country-risk/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: country-risk
 type: application
-version: 4.0.1
-appVersion: "2.0.0-alpha"
+version: 4.0.2
+appVersion: "2.0.0"
 description: A Helm chart for deploying the Country Risk service
 home: https://github.com/eclipse-tractusx/vas-country-risk-frontend
 sources:


### PR DESCRIPTION
## Description
Release a new version of country risk with v2.0.0 for app and 4.0.2 for charts
Holding all changes done for the QG 24.05


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
